### PR TITLE
parse docstring

### DIFF
--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -8,20 +8,22 @@ Unquoted { Unquote expression }
 Metadata { Meta expression expression }
 SyntaxQuoted { SyntaxQuote expression }
 
-@precedence { listOperator @cut, specializedString @cut }
+@precedence { listOperator @cut, docString @left }
 
 listContents {
-  defList { !listOperator Def Symbol (DocumentedExpression | undocumentedExpression)? } |
+  defList { !listOperator Def Symbol (documentedExpression | undocumentedExpression)? } |
   anyList { expression* }
 }
 
-DocumentedExpression { String ~cont expression+ }
+documentedExpression { DocString ~cont expression+ }
 undocumentedExpression { expression ~cont expression* }
 
 List { "(" listContents ")" }
 Vector { "[" expression* "]" }
 Map { "{" (expression expression)* "}" }
 Set { "#{" expression* "}" }
+
+DocString { !docString String }
 
 @tokens {
   whitespace { (std.whitespace | ",")+ }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -174,11 +174,11 @@ Program(Deref,Symbol)
 
 # Def + DocString + Keyword
 (def foo "doc" :foo)
-==> Program(List("(",Def,Symbol,DocumentedExpression(String,Keyword),")"))
+==> Program(List("(",Def,Symbol,DocString(String),Keyword,")"))
 
 # Def + DocString + String + String
 (def foo "doc" "foo" "bar")
-==> Program(List("(",Def,Symbol,DocumentedExpression(String,String,String),")"))
+==> Program(List("(",Def,Symbol,DocString(String),String,String,")"))
 
 # Destructuring
 (let [{:keys [hello]} world]


### PR DESCRIPTION
use anonymous `listContents` to differentiate types of lists, and a precedence operator to parse a `defList` whenever `def` is the first item in a list.