### PR TITLE
Allow multiple metadata on defs, varName & operators

### DIFF
--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -25,11 +25,11 @@ VarName { Symbol }
   ReaderConditional { "#?" (List | Deref) }
   DataLiteral { "#" ident }
   SymbolicValue { "##" simpleIdent }
-  Metadata<t> { ("^" | "#^") t }
+  Metadata { ("^" | "#^") expression }
   String { '"' StringContent? '"' }
 }
 
-Meta<t> { Metadata<t> !meta t }
+Meta<t> { Metadata !meta t }
 
 Deref { "@" expression }
 Quote { "'" expression }

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -1,13 +1,13 @@
 @top[name=Program] { expression* }
 
 @skip { whitespace | LineComment | Discard }
-expression { Boolean | Nil | Deref | Quote | SyntaxQuote | Unquote | UnquoteSplice | Symbol | Number | Meta | Keyword | List | Vector | Map | String | Character | Set | NamespacedMap | RegExp | Var | ReaderConditional | DataLiteral | SymbolicValue | AnonymousFunction | FnArg | Meta }
+expression { Boolean | Nil | Deref | Quote | SyntaxQuote | Unquote | UnquoteSplice | Symbol | Number | Keyword | List | Vector | Map | String | Character | Set | NamespacedMap | RegExp | Var | ReaderConditional | DataLiteral | SymbolicValue | AnonymousFunction | FnArg | Meta<expression> }
 Discard { "#_" expression }
 @precedence { docString @left, operator @left, meta @right }
 
 listContents {
-   defList  { Metadata? DefLike Metadata? VarName (DocString expression+ | expression+)? } |
-   anyList { (Metadata? Operator)? expression* }
+   defList  { (DefLike | Meta<DefLike>) (VarName | Meta<VarName>) (DocString expression+ | expression+)? } |
+   anyList { (Operator | Meta<Operator>)? expression* }
  }
 
 DocString { !docString String }
@@ -25,11 +25,11 @@ VarName { Symbol }
   ReaderConditional { "#?" (List | Deref) }
   DataLiteral { "#" ident }
   SymbolicValue { "##" simpleIdent }
-  Metadata { ("^" | "#^") expression }
+  Metadata<t> { ("^" | "#^") t }
   String { '"' StringContent? '"' }
 }
 
-Meta { Metadata !meta expression }
+Meta<t> { Metadata<t> !meta t }
 
 Deref { "@" expression }
 Quote { "'" expression }

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -6,8 +6,8 @@ Discard { "#_" expression }
 @precedence { docString @left, operator @left, meta @right }
 
 listContents {
-   defList  { (DefLike | Meta<DefLike>) (VarName | Meta<VarName>) (DocString expression+ | expression+)? } |
-   anyList { (Operator | Meta<Operator>)? expression* }
+   defList  { defLikeWithMeta varNameWithMeta (DocString expression+ | expression+)? } |
+   anyList { operatorWithMeta? expression* }
  }
 
 DocString { !docString String }
@@ -37,6 +37,10 @@ SyntaxQuote { "`" expression }
 Unquote { "~" expression }
 UnquoteSplice { "~@" expression }
 Symbol { ident }
+operatorWithMeta { Operator | Meta<operatorWithMeta> }
+defLikeWithMeta { DefLike | Meta<defLikeWithMeta> }
+varNameWithMeta { VarName | Meta<varNameWithMeta> }
+
 Operator { !operator ident }
 
 @tokens {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -220,9 +220,9 @@ sym#
 
 # Meta Multiple Def
 (^:hello ^world def foo)
-==> Program(List(Meta(Metadata(Keyword),Meta(Metadata(Symbol),DefLike)), Symbol))
+==> Program(List(Meta(Metadata(Keyword),Meta(Metadata(Symbol),DefLike)), VarName(Symbol)))
 
 # Meta Multiple VarName
 (def ^:static ^clojure.lang.ChunkBuffer chunk-buffer)
-==> Program(List(DefLike,Meta(Metadata(Keyword),Meta(Metadata(Symbol),VarName(Symbol))))
+==> Program(List(DefLike,Meta(Metadata(Keyword),Meta(Metadata(Symbol),VarName(Symbol)))))
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -165,6 +165,15 @@ Program(Deref(Symbol))
 ^:dynamic ^ints obj
 ==> Program(Meta(Metadata(Keyword),Meta(Metadata(Symbol),Symbol)))
 
+# Meta Operator
+(^:dynamic + 1)
+==> Program(List(Meta(Metadata(Keyword),Operator), Number))
+
+# Meta Multiple Operator
+(^:dynamic ^ints + 1 2)
+==> Program(List(Meta(Metadata(Keyword),Meta(Metadata(Symbol),Operator)), Number, Number))
+
+
 # Var
 #'hello
 ==> Program(Var(Symbol))
@@ -203,8 +212,17 @@ sym#
 
 # Def + String
 (defn foo "string")
-==> Program(List("(",DefLike,VarName(Symbol),String(StringContent),")"))
+==> Program(List(DefLike,VarName(Symbol),String(StringContent)))
 
 # Def + DocString
 (defn foo "string" :bar)
-==> Program(List("(",DefLike,VarName(Symbol),DocString(String(StringContent)),Keyword")"))
+==> Program(List(DefLike,VarName(Symbol),DocString(String(StringContent)),Keyword))
+
+# Meta Multiple Def
+(^:hello ^world def foo)
+==> Program(List(Meta(Metadata(Keyword),Meta(Metadata(Symbol),DefLike)), Symbol))
+
+# Meta Multiple VarName
+(def ^:static ^clojure.lang.ChunkBuffer chunk-buffer)
+==> Program(List(DefLike,Meta(Metadata(Keyword),Meta(Metadata(Symbol),VarName(Symbol))))
+


### PR DESCRIPTION
This is my (so far unsuccessful) attempt at allowing multiple metadata expressions on `DefLike`, `VarName` and `Operator`.