### PR TITLE
Constructor Call Syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /src/parser.*
 .tern-*
 /dist
+.idea
+debug

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,4 @@
 /node_modules
+.idea
+debug
+.github

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -25,7 +25,7 @@ VarName { Symbol }
 
 @skip {} {
   ReaderTag { "#" ReaderTagIdent }
-  ConstructorPrefix { "#" QualifiedJavaIdent }
+  ConstructorPrefix[prefixEdge] { "#" QualifiedJavaIdent }
 
   SymbolicValue { "##" ident }
   Set[prefixColl] { "#" Map }

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -10,7 +10,7 @@
 
 expression { Boolean | Nil | Deref | Quote | SyntaxQuote | Unquote | UnquoteSplice | Symbol | Number | Keyword | List | Vector | Map | String | Character | Set | NamespacedMap | RegExp | Var | ReaderConditional | SymbolicValue | AnonymousFunction | Meta<expression> | TaggedLiteral<expression> | ConstructorCall }
 Discard { "#_" expression }
-@precedence { docString @left, operator @left, meta @right, prefixLiteral @right }
+@precedence { docString @left, operator @left, meta @right}
 
 listContents {
    defList { defLikeWithMeta varNameWithMeta (DocString expression+ | expression+)? } |
@@ -25,7 +25,7 @@ VarName { Symbol }
 
 @skip {} {
   ReaderTag { "#" Symbol }
-  ConstructorPrefix { "#" !prefixLiteral dottedIdent }
+  ConstructorPrefix { "#" DottedIdent }
 
   SymbolicValue { "##" ident }
   Set[prefixColl] { "#" Map }
@@ -88,12 +88,14 @@ Operator { !operator Symbol }
 
   LineComment { ";" ![\n]* }
 
+  fragment { std.asciiLetter+ }
+  DottedIdent { fragment ("." fragment)+ }
+
   identStart { std.asciiLetter | $[<>&%._=?!*+\-$\u{a1}-\u{10ff}/] }
   identChar { identStart | std.digit | ":" | "'" | "#" | "/"}
   ident { identStart identChar* }
-  dottedIdent { ident ("." ident)+ }
-  Symbol { ident | dottedIdent }
-  
+  Symbol { ident }
+
   keyword { ":" ":"? ident? } // the invalid token :: can also be considered as a keyword
   Keyword { keyword }
 
@@ -105,7 +107,7 @@ Operator { !operator Symbol }
     "0b" $[01]+ |
     "0o" $[0-7]+
   }
-  @precedence { Number, dottedIdent, Symbol }
+  @precedence { Number, DottedIdent, Symbol }
 
   StringContent {
     (!["] | "\\" _)+

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -8,7 +8,7 @@
 
 @skip { whitespace | LineComment | Discard }
 
-expression { Boolean | Nil | Deref | Quote | SyntaxQuote | Unquote | UnquoteSplice | Symbol | Number | Keyword | List | Vector | Map | String | Character | Set | NamespacedMap | RegExp | Var | ReaderConditional | SymbolicValue | AnonymousFunction | Meta<expression> | TaggedLiteral<expression> }
+expression { Boolean | Nil | Deref | Quote | SyntaxQuote | Unquote | UnquoteSplice | Symbol | Number | Keyword | List | Vector | Map | String | Character | Set | NamespacedMap | RegExp | Var | ReaderConditional | SymbolicValue | AnonymousFunction | Meta<expression> | TaggedLiteral<expression> | ConstructorCall }
 Discard { "#_" expression }
 @precedence { docString @left, operator @left, meta @right, prefixLiteral @right }
 
@@ -25,6 +25,8 @@ VarName { Symbol }
 
 @skip {} {
   ReaderTag { "#" Symbol }
+  ConstructorPrefix { "#" !prefixLiteral dottedIdent }
+
   SymbolicValue { "##" ident }
   Set[prefixColl] { "#" Map }
   AnonymousFunction[prefixColl] { "#" List }
@@ -42,6 +44,7 @@ VarName { Symbol }
 
 Meta[prefixContainer]<t> { (Metadata | ReaderMetadata) !meta t }
 TaggedLiteral[prefixContainer]<t> { ReaderTag t }
+ConstructorCall[prefixContainer] { ConstructorPrefix (Map | Vector) }
 
 Deref[prefixColl] { "@" expression }
 Quote[prefixColl] { "'" expression }
@@ -88,8 +91,9 @@ Operator { !operator Symbol }
   identStart { std.asciiLetter | $[<>&%._=?!*+\-$\u{a1}-\u{10ff}/] }
   identChar { identStart | std.digit | ":" | "'" | "#" | "/"}
   ident { identStart identChar* }
-  Symbol { ident }
-
+  dottedIdent { ident ("." ident)+ }
+  Symbol { ident | dottedIdent }
+  
   keyword { ":" ":"? ident? } // the invalid token :: can also be considered as a keyword
   Keyword { keyword }
 
@@ -101,7 +105,7 @@ Operator { !operator Symbol }
     "0b" $[01]+ |
     "0o" $[0-7]+
   }
-  @precedence { Number, Symbol }
+  @precedence { Number, dottedIdent, Symbol }
 
   StringContent {
     (!["] | "\\" _)+

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -24,8 +24,8 @@ Map[coll] { "{" expression* "}" }
 VarName { Symbol }
 
 @skip {} {
-  ReaderTag { "#" Symbol }
-  ConstructorPrefix { "#" DottedIdent }
+  ReaderTag { "#" ReaderTagIdent }
+  ConstructorPrefix { "#" QualifiedJavaIdent }
 
   SymbolicValue { "##" ident }
   Set[prefixColl] { "#" Map }
@@ -44,6 +44,8 @@ VarName { Symbol }
 
 Meta[prefixContainer]<t> { (Metadata | ReaderMetadata) !meta t }
 TaggedLiteral[prefixContainer]<t> { ReaderTag t }
+
+// https://clojure.org/reference/reader#_deftype_defrecord_and_constructor_calls_version_1_3_and_later
 ConstructorCall[prefixContainer] { ConstructorPrefix (Map | Vector) }
 
 Deref[prefixColl] { "@" expression }
@@ -88,8 +90,17 @@ Operator { !operator Symbol }
 
   LineComment { ";" ![\n]* }
 
-  fragment { std.asciiLetter+ } // TBD
-  DottedIdent { fragment ("." fragment)+ }
+  // https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8
+  // class or constructor names
+  javaIdentStart { std.asciiLetter | "_" | "$" | $[\u{a1}-\u{10ff}] }
+  javaIdentPart { javaIdentStart | std.digit }
+  javaIdent { javaIdentStart javaIdentPart* }
+  QualifiedJavaIdent { javaIdent ("." javaIdent)+ }
+
+  // reader tags cannot contain dots
+  readerTagIdentStart { std.asciiLetter | $[<>&%_=?!*+\-$\u{a1}-\u{10ff}] }
+  readerTagChar { readerTagIdentStart | "/" | std.digit }
+  ReaderTagIdent { readerTagIdentStart readerTagChar* }
 
   identStart { std.asciiLetter | $[<>&%._=?!*+\-$\u{a1}-\u{10ff}/] }
   identChar { identStart | std.digit | ":" | "'" | "#" | "/"}
@@ -107,7 +118,7 @@ Operator { !operator Symbol }
     "0b" $[01]+ |
     "0o" $[0-7]+
   }
-  @precedence { Number, DottedIdent, Symbol }
+  @precedence { Number, QualifiedJavaIdent, ReaderTagIdent, Symbol }
 
   StringContent {
     (!["] | "\\" _)+

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -93,14 +93,14 @@ Operator { !operator Symbol }
   // https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8
   // class or constructor names
   javaIdentStart { std.asciiLetter | "_" | "$" | $[\u{a1}-\u{10ff}] }
-  javaIdentPart { javaIdentStart | std.digit }
-  javaIdent { javaIdentStart javaIdentPart* }
+  javaIdentChar { javaIdentStart | std.digit }
+  javaIdent { javaIdentStart javaIdentChar* }
   qualifiedJavaIdent { javaIdent ("." javaIdent)+ }
 
   // reader tags cannot contain dots
   readerTagIdentStart { std.asciiLetter | $[<>&%_=?!*+\-$\u{a1}-\u{10ff}] }
-  readerTagChar { readerTagIdentStart | "/" | std.digit }
-  readerTagIdent { readerTagIdentStart readerTagChar* }
+  readerTagIdentChar { readerTagIdentStart | "/" | std.digit }
+  readerTagIdent { readerTagIdentStart readerTagIdentChar* }
 
   identStart { std.asciiLetter | $[<>&%._=?!*+\-$\u{a1}-\u{10ff}/] }
   identChar { identStart | std.digit | ":" | "'" | "#" | "/"}

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -24,8 +24,8 @@ Map[coll] { "{" expression* "}" }
 VarName { Symbol }
 
 @skip {} {
-  ReaderTag { "#" ReaderTagIdent }
-  ConstructorPrefix[prefixEdge] { "#" QualifiedJavaIdent }
+  ReaderTag { "#" readerTagIdent }
+  ConstructorPrefix[prefixEdge] { "#" qualifiedJavaIdent }
 
   SymbolicValue { "##" ident }
   Set[prefixColl] { "#" Map }
@@ -95,12 +95,12 @@ Operator { !operator Symbol }
   javaIdentStart { std.asciiLetter | "_" | "$" | $[\u{a1}-\u{10ff}] }
   javaIdentPart { javaIdentStart | std.digit }
   javaIdent { javaIdentStart javaIdentPart* }
-  QualifiedJavaIdent { javaIdent ("." javaIdent)+ }
+  qualifiedJavaIdent { javaIdent ("." javaIdent)+ }
 
   // reader tags cannot contain dots
   readerTagIdentStart { std.asciiLetter | $[<>&%_=?!*+\-$\u{a1}-\u{10ff}] }
   readerTagChar { readerTagIdentStart | "/" | std.digit }
-  ReaderTagIdent { readerTagIdentStart readerTagChar* }
+  readerTagIdent { readerTagIdentStart readerTagChar* }
 
   identStart { std.asciiLetter | $[<>&%._=?!*+\-$\u{a1}-\u{10ff}/] }
   identChar { identStart | std.digit | ":" | "'" | "#" | "/"}
@@ -118,7 +118,7 @@ Operator { !operator Symbol }
     "0b" $[01]+ |
     "0o" $[0-7]+
   }
-  @precedence { Number, QualifiedJavaIdent, ReaderTagIdent, Symbol }
+  @precedence { Number, qualifiedJavaIdent, readerTagIdent, Symbol }
 
   StringContent {
     (!["] | "\\" _)+

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -88,7 +88,7 @@ Operator { !operator Symbol }
 
   LineComment { ";" ![\n]* }
 
-  fragment { std.asciiLetter+ }
+  fragment { std.asciiLetter+ } // TBD
   DottedIdent { fragment ("." fragment)+ }
 
   identStart { std.asciiLetter | $[<>&%._=?!*+\-$\u{a1}-\u{10ff}/] }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -158,7 +158,7 @@ Program(Discard(Discard(Keyword), Symbol), String(StringContent))
 # Discarded Tagged Literal
 #_#hello/world [1] :foo
 ==>
-Program(Discard("#_", TaggedLiteral(ReaderTag("#", ReaderTagIdent) Vector("[",Number,"]"))), Keyword)
+Program(Discard("#_", TaggedLiteral(ReaderTag("#") Vector("[",Number,"]"))), Keyword)
 
 # Deref
 @hello
@@ -208,15 +208,15 @@ Program(Deref(Symbol))
 
 # Built-in Tagged Literal
 #uuid "31d20ceb-c7c2-40bb-9bd5-1e1e05f57ea1"
-==> Program(TaggedLiteral(ReaderTag("#", ReaderTagIdent), String(StringContent)))
+==> Program(TaggedLiteral(ReaderTag("#"), String(StringContent)))
 
 # Reader Tag with namespace
 #my/foo [1]
-==> Program(TaggedLiteral(ReaderTag("#", ReaderTagIdent),Vector("[",Number,"]")))
+==> Program(TaggedLiteral(ReaderTag("#"),Vector("[",Number,"]")))
 
 # Tagged Literal with multiple tags
 #tag/one #tag/two []
-==> Program(TaggedLiteral(ReaderTag("#", ReaderTagIdent), TaggedLiteral(ReaderTag("#", ReaderTagIdent), Vector)))
+==> Program(TaggedLiteral(ReaderTag("#"), TaggedLiteral(ReaderTag("#"), Vector)))
 
 # Symbolic Value
 ##Inf, ##-Inf
@@ -280,17 +280,17 @@ sym#
 
 # Constructor Call with Vector
 #my.klass_or_type_or_record[:a :b :c]
-==> Program(ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Vector("[",Keyword,Keyword,Keyword,"]")))
+==> Program(ConstructorCall(ConstructorPrefix("#"),Vector("[",Keyword,Keyword,Keyword,"]")))
 
 # Constructor Call with Vector
 #my.γωνστρυγτωρ[:a :b :c]
-==> Program(ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Vector("[",Keyword,Keyword,Keyword,"]")))
+==> Program(ConstructorCall(ConstructorPrefix("#"),Vector("[",Keyword,Keyword,Keyword,"]")))
 
 # Constructor Call with Record
 #my.record{:a 1, :b 2}
-==> Program(ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Map("{",Keyword,Number,Keyword,Number,"}")))
+==> Program(ConstructorCall(ConstructorPrefix("#"),Map("{",Keyword,Number,Keyword,Number,"}")))
 
 # Constructor with Reader Tags
 #read/this #my.constructor [] #read/that #my.record {}
-==> Program(TaggedLiteral(ReaderTag("#",ReaderTagIdent),ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Vector("[","]"))),
-            TaggedLiteral(ReaderTag("#",ReaderTagIdent),ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Map("{","}"))))
+==> Program(TaggedLiteral(ReaderTag("#"),ConstructorCall(ConstructorPrefix("#"),Vector("[","]"))),
+            TaggedLiteral(ReaderTag("#"),ConstructorCall(ConstructorPrefix("#"),Map("{","}"))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -279,7 +279,7 @@ sym#
 ==> Program(ConstructorCall(ConstructorPrefix("#", DottedIdent),Vector("[",Number,"]")))
 
 # A Symbol with dots in namespace
-foo.bar/Bang
+my.ns/foo
 ==> Program(Symbol)
 
 # Reader Tag with namespace

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -158,7 +158,7 @@ Program(Discard(Discard(Keyword), Symbol), String(StringContent))
 # Discarded Tagged Literal
 #_#hello/world [1] :foo
 ==>
-Program(Discard("#_", TaggedLiteral(ReaderTag("#", Symbol) Vector("[",Number,"]"))), Keyword)
+Program(Discard("#_", TaggedLiteral(ReaderTag("#", ReaderTagIdent) Vector("[",Number,"]"))), Keyword)
 
 # Deref
 @hello
@@ -206,13 +206,17 @@ Program(Deref(Symbol))
 #?(:cljs "hello") #?@(:cljs ["hello"])
 ==> Program(ReaderConditional("#?", List(Keyword,String(StringContent))),ReaderConditional(Deref(List(Keyword,Vector(String(StringContent))))))
 
-# Tagged Literal
+# Built-in Tagged Literal
 #uuid "31d20ceb-c7c2-40bb-9bd5-1e1e05f57ea1"
-==> Program(TaggedLiteral(ReaderTag("#", Symbol), String(StringContent)))
+==> Program(TaggedLiteral(ReaderTag("#", ReaderTagIdent), String(StringContent)))
+
+# Reader Tag with namespace
+#my/foo [1]
+==> Program(TaggedLiteral(ReaderTag("#", ReaderTagIdent),Vector("[",Number,"]")))
 
 # Tagged Literal with multiple tags
 #tag/one #tag/two []
-==> Program(TaggedLiteral(ReaderTag("#", Symbol), TaggedLiteral(ReaderTag("#", Symbol), Vector)))
+==> Program(TaggedLiteral(ReaderTag("#", ReaderTagIdent), TaggedLiteral(ReaderTag("#", ReaderTagIdent), Vector)))
 
 # Symbolic Value
 ##Inf, ##-Inf
@@ -274,18 +278,19 @@ sym#
 /
 ==> Program(Symbol)
 
-# Constructor
-#my.foo [1]
-==> Program(ConstructorCall(ConstructorPrefix("#", DottedIdent),Vector("[",Number,"]")))
+# Constructor Call with Vector
+#my.klass_or_type_or_record[:a :b :c]
+==> Program(ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Vector("[",Keyword,Keyword,Keyword,"]")))
 
-# A Symbol with dots in namespace
-my.ns/foo
-==> Program(Symbol)
+# Constructor Call with Vector
+#my.γωνστρυγτωρ[:a :b :c]
+==> Program(ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Vector("[",Keyword,Keyword,Keyword,"]")))
 
-# Reader Tag with namespace
-#my/foo [1]
-==> Program(TaggedLiteral(ReaderTag("#", Symbol),Vector("[",Number,"]")))
+# Constructor Call with Record
+#my.record{:a 1, :b 2}
+==> Program(ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Map("{",Keyword,Number,Keyword,Number,"}")))
 
-# Reader Tag with dotted namespace
-#my.ns/foo [1]
-==> Program(TaggedLiteral(ReaderTag("#", Symbol),Vector("[",Number,"]")))
+# Constructor with Reader Tags
+#read/this #my.constructor [] #read/that #my.record {}
+==> Program(TaggedLiteral(ReaderTag("#",ReaderTagIdent),ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Vector("[","]"))),
+            TaggedLiteral(ReaderTag("#",ReaderTagIdent),ConstructorCall(ConstructorPrefix("#",QualifiedJavaIdent),Map("{","}"))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -275,14 +275,17 @@ sym#
 ==> Program(Symbol)
 
 # Constructor
-#my.Foo [1]
-==> Program(ConstructorCall(ConstructorPrefix("#"),Vector("[",Number,"]")))
+#my.foo [1]
+==> Program(ConstructorCall(ConstructorPrefix("#", DottedIdent),Vector("[",Number,"]")))
 
-
-# Maybe
-foo.Bar
+# A Symbol with dots in namespace
+foo.bar/Bang
 ==> Program(Symbol)
 
-# Reader
-#my.foo/foo [1]
+# Reader Tag with namespace
+#my/foo [1]
+==> Program(TaggedLiteral(ReaderTag("#", Symbol),Vector("[",Number,"]")))
+
+# Reader Tag with dotted namespace
+#my.ns/foo [1]
 ==> Program(TaggedLiteral(ReaderTag("#", Symbol),Vector("[",Number,"]")))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -273,3 +273,16 @@ sym#
 # Division
 /
 ==> Program(Symbol)
+
+# Constructor
+#my.Foo [1]
+==> Program(ConstructorCall(ConstructorPrefix("#"),Vector("[",Number,"]")))
+
+
+# Maybe
+foo.Bar
+==> Program(Symbol)
+
+# Reader
+#my.foo/foo [1]
+==> Program(TaggedLiteral(ReaderTag("#", Symbol),Vector("[",Number,"]")))


### PR DESCRIPTION
Reintroduce [constructor call syntax](https://clojure.org/reference/reader#_deftype_defrecord_and_constructor_calls_version_1_3_and_later) after removal for compatibility with @lezer/generator 1.0.0.